### PR TITLE
PS-9148: implemented lazy query_cache initial population

### DIFF
--- a/components/masking_functions/include/masking_functions/command_service_tuple.hpp
+++ b/components/masking_functions/include/masking_functions/command_service_tuple.hpp
@@ -35,6 +35,7 @@ namespace masking_functions {
 //   mysql_command_query{
 //     mysql_service_mysql_command_query,
 //     mysql_service_mysql_command_query_result,
+//     mysql_service_mysql_command_field_info,
 //     mysql_service_mysql_command_options,
 //     mysql_service_mysql_command_factory
 //   };
@@ -43,6 +44,7 @@ namespace masking_functions {
 struct command_service_tuple {
   SERVICE_TYPE(mysql_command_query) * query;
   SERVICE_TYPE(mysql_command_query_result) * query_result;
+  SERVICE_TYPE(mysql_command_field_info) * field_info;
   SERVICE_TYPE(mysql_command_options) * options;
   SERVICE_TYPE(mysql_command_factory) * factory;
 };

--- a/components/masking_functions/include/masking_functions/query_cache.hpp
+++ b/components/masking_functions/include/masking_functions/query_cache.hpp
@@ -50,12 +50,14 @@ class query_cache {
   bool remove(const std::string &dictionary_name, const std::string &term);
   bool insert(const std::string &dictionary_name, const std::string &term);
 
-  bool load_cache();
+  void reload_cache();
 
  private:
-  bookshelf_ptr m_dict_cache;
-
   query_builder_ptr m_query_builder;
+
+  // TODO: in c++20 change this to std::atomic<bookshelf_ptr> and
+  //       remove deprecated atomic_load() / atomic_store()
+  mutable bookshelf_ptr m_dict_cache;
 
   std::uint64_t m_flusher_interval_seconds;
   std::atomic<bool> m_is_flusher_stopped;
@@ -72,6 +74,10 @@ class query_cache {
   void dict_flusher() noexcept;
 
   static void *run_dict_flusher(void *arg);
+
+  bookshelf_ptr create_dict_cache_internal() const;
+  // returning deliberately by value to increase reference counter
+  bookshelf_ptr get_pinned_dict_cache_internal() const;
 };
 
 }  // namespace masking_functions

--- a/components/masking_functions/src/component.cpp
+++ b/components/masking_functions/src/component.cpp
@@ -60,6 +60,7 @@ REQUIRES_SERVICE_PLACEHOLDER(mysql_string_compare);
 
 REQUIRES_SERVICE_PLACEHOLDER(mysql_command_query);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_command_query_result);
+REQUIRES_SERVICE_PLACEHOLDER(mysql_command_field_info);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_command_options);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_command_factory);
 
@@ -118,6 +119,7 @@ static mysql_service_status_t component_init() {
           // TODO: convert this to designated initializers in c++20
           mysql_service_mysql_command_query,
           mysql_service_mysql_command_query_result,
+          mysql_service_mysql_command_field_info,
           mysql_service_mysql_command_options,
           mysql_service_mysql_command_factory};
   masking_functions::primitive_singleton<
@@ -227,6 +229,7 @@ BEGIN_COMPONENT_REQUIRES(CURRENT_COMPONENT_NAME)
 
   REQUIRES_SERVICE(mysql_command_query),
   REQUIRES_SERVICE(mysql_command_query_result),
+  REQUIRES_SERVICE(mysql_command_field_info),
   REQUIRES_SERVICE(mysql_command_options),
   REQUIRES_SERVICE(mysql_command_factory),
 

--- a/components/masking_functions/src/masking_functions/registration_routines.cpp
+++ b/components/masking_functions/src/masking_functions/registration_routines.cpp
@@ -1061,9 +1061,7 @@ class masking_dictionaries_flush_impl {
 
   mysqlpp::udf_result_t<STRING_RESULT> calculate(const mysqlpp::udf_context &ctx
                                                  [[maybe_unused]]) {
-    if (!global_query_cache::instance()->load_cache()) {
-      return std::nullopt;
-    }
+    global_query_cache::instance()->reload_cache();
 
     return "1";
   }

--- a/mysql-test/suite/component_masking_functions/r/dictionary_operations.result
+++ b/mysql-test/suite/component_masking_functions/r/dictionary_operations.result
@@ -59,6 +59,8 @@ SELECT gen_blocklist('Berlin', 'de_cities', 'us_cities');
 ERROR HY000: Error in command service backend interface, because of : "Table 'mysql.masking_dictionaries' doesn't exist"
 SELECT gen_dictionary('us_cities');
 ERROR HY000: Error in command service backend interface, because of : "Table 'mysql.masking_dictionaries' doesn't exist"
+SELECT masking_dictionaries_flush();
+ERROR HY000: Error in command service backend interface, because of : "Table 'mysql.masking_dictionaries' doesn't exist"
 #
 # NULL for NULL checks
 include/assert.inc [gen_blocklist() for the NULL primary argument should return NULL]
@@ -97,12 +99,30 @@ include/assert.inc [collation of the result of evaluating 'gen_blocklist('Berlin
 INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city1');
 INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city2');
 INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city3');
-INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city4');
 INSERT INTO mysql.masking_dictionaries VALUES('укр_міста', 'місто1');
-INSERT INTO mysql.masking_dictionaries VALUES('укр_міста', 'місто2');
+include/assert.inc [gen_dictionary on a existing but not flushed dictionary must return NULL]
 SELECT masking_dictionaries_flush();
 masking_dictionaries_flush()
 1
+include/assert.inc [the number of distinct US city names after the first insert and flush must be 3]
+INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city4');
+INSERT INTO mysql.masking_dictionaries VALUES('укр_міста', 'місто2');
+include/assert.inc [the number of distinct US city names after the second insert but before flush must be 3]
+SELECT masking_dictionaries_flush();
+masking_dictionaries_flush()
+1
+include/assert.inc [the number of distinct US city names after the second insert and flush must be 4]
+RENAME TABLE mysql.masking_dictionaries TO mysql.masking_dictionaries_hidden;
+include/assert.inc [the number of distinct US city names after hiding dict table must be 4]
+SELECT masking_dictionaries_flush();
+ERROR HY000: Error in command service backend interface, because of : "Table 'mysql.masking_dictionaries' doesn't exist"
+include/assert.inc [the number of distinct US city names after dict unsuccessful flush must be 4]
+RENAME TABLE mysql.masking_dictionaries_hidden TO mysql.masking_dictionaries;
+include/assert.inc [the number of distinct US city names after restoring dict table must be 4]
+SELECT masking_dictionaries_flush();
+masking_dictionaries_flush()
+1
+include/assert.inc [the number of distinct US city names after restoring dict table and flush must be 4]
 include/assert.inc [gen_dictionary on a non-existing dictionary must return NULL]
 SET @check_expression_result = gen_dictionary('us_cities');
 include/assert.inc [the result of evaluating 'gen_dictionary('us_cities')' must match the 'city[[:digit:]]{1}' pattern]

--- a/mysql-test/suite/component_masking_functions/t/dictionary_operations.test
+++ b/mysql-test/suite/component_masking_functions/t/dictionary_operations.test
@@ -83,6 +83,11 @@ SELECT gen_blocklist('Berlin', 'de_cities', 'us_cities');
 --error ER_COMMAND_SERVICE_BACKEND_FAILED
 SELECT gen_dictionary('us_cities');
 
+--connection con_priv
+--error ER_COMMAND_SERVICE_BACKEND_FAILED
+SELECT masking_dictionaries_flush();
+--connection con_unpriv
+
 
 --echo #
 --echo # NULL for NULL checks
@@ -148,13 +153,70 @@ CREATE TABLE mysql.masking_dictionaries(
 INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city1');
 INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city2');
 INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city3');
-INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city4');
 INSERT INTO mysql.masking_dictionaries VALUES('укр_міста', 'місто1');
-INSERT INTO mysql.masking_dictionaries VALUES('укр_міста', 'місто2');
+
+--let $assert_cond = gen_dictionary("us_cities") IS NULL
+--let $assert_text = gen_dictionary on a existing but not flushed dictionary must return NULL
+--source include/assert.inc
 
 --connection con_priv
 SELECT masking_dictionaries_flush();
 --connection con_unpriv
+
+--let $assert_cond = [ SELECT GROUP_CONCAT(val ORDER BY val) = "city1,city2,city3" FROM (SELECT gen_dictionary("us_cities") AS term FROM SEQUENCE_TABLE(100) AS tt GROUP BY term) AS tbl(val) ] = 1
+--let $assert_text = the number of distinct US city names after the first insert and flush must be 3
+--source include/assert.inc
+
+--connection default
+INSERT INTO mysql.masking_dictionaries VALUES('us_cities', 'city4');
+INSERT INTO mysql.masking_dictionaries VALUES('укр_міста', 'місто2');
+
+--connection con_unpriv
+--let $assert_cond = [ SELECT GROUP_CONCAT(val ORDER BY val) = "city1,city2,city3" FROM (SELECT gen_dictionary("us_cities") AS term FROM SEQUENCE_TABLE(100) AS tt GROUP BY term) AS tbl(val) ] = 1
+--let $assert_text = the number of distinct US city names after the second insert but before flush must be 3
+--source include/assert.inc
+
+--connection con_priv
+SELECT masking_dictionaries_flush();
+--connection con_unpriv
+
+--let $assert_cond = [ SELECT GROUP_CONCAT(val ORDER BY val) = "city1,city2,city3,city4" FROM (SELECT gen_dictionary("us_cities") AS term FROM SEQUENCE_TABLE(100) AS tt GROUP BY term) AS tbl(val) ] = 1
+--let $assert_text = the number of distinct US city names after the second insert and flush must be 4
+--source include/assert.inc
+
+--connection default
+RENAME TABLE mysql.masking_dictionaries TO mysql.masking_dictionaries_hidden;
+--connection con_unpriv
+
+--let $assert_cond = [ SELECT GROUP_CONCAT(val ORDER BY val) = "city1,city2,city3,city4" FROM (SELECT gen_dictionary("us_cities") AS term FROM SEQUENCE_TABLE(100) AS tt GROUP BY term) AS tbl(val) ] = 1
+--let $assert_text = the number of distinct US city names after hiding dict table must be 4
+--source include/assert.inc
+
+--connection con_priv
+--error ER_COMMAND_SERVICE_BACKEND_FAILED
+SELECT masking_dictionaries_flush();
+--connection con_unpriv
+
+--let $assert_cond = [ SELECT GROUP_CONCAT(val ORDER BY val) = "city1,city2,city3,city4" FROM (SELECT gen_dictionary("us_cities") AS term FROM SEQUENCE_TABLE(100) AS tt GROUP BY term) AS tbl(val) ] = 1
+--let $assert_text = the number of distinct US city names after dict unsuccessful flush must be 4
+--source include/assert.inc
+
+--connection default
+RENAME TABLE mysql.masking_dictionaries_hidden TO mysql.masking_dictionaries;
+--connection con_unpriv
+
+--let $assert_cond = [ SELECT GROUP_CONCAT(val ORDER BY val) = "city1,city2,city3,city4" FROM (SELECT gen_dictionary("us_cities") AS term FROM SEQUENCE_TABLE(100) AS tt GROUP BY term) AS tbl(val) ] = 1
+--let $assert_text = the number of distinct US city names after restoring dict table must be 4
+--source include/assert.inc
+
+--connection con_priv
+SELECT masking_dictionaries_flush();
+--connection con_unpriv
+
+--let $assert_cond = [ SELECT GROUP_CONCAT(val ORDER BY val) = "city1,city2,city3,city4" FROM (SELECT gen_dictionary("us_cities") AS term FROM SEQUENCE_TABLE(100) AS tt GROUP BY term) AS tbl(val) ] = 1
+--let $assert_text = the number of distinct US city names after restoring dict table and flush must be 4
+--source include/assert.inc
+
 
 --let $assert_cond = gen_dictionary("de_cities") IS NULL
 --let $assert_text = gen_dictionary on a non-existing dictionary must return NULL


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9148

'command_service_tuple' struct extended with one more member - 'field_info' service.

Reworked 'query_cache' class: instead of loading terms from the database in constructor, this operation is now performed in first attempt to access one of the dictionary methods ('contains()' / 'get_random()' / 'remove()' / 'insert()'). This is done in order to overcome a limitation that does not allow 'mysql_command_query' service to be used from inside the componment initialization function.
Fixed problem with 'm_dict_cache' shared pointer updated concurrently from different threads.
Exceptions thrown from the cache loading function no longer escape the flusher thread.

De-coupled 'sql_context' and 'bookshelf' classes: 'sql_context' now accepts a generic insertion callback that can be used to populate any type of containers.

'component_masking_functions.dictionary_operations' MTR test case extended with additional checks for flushed / unflushed dictionary cache.