### PR TITLE
PS-9148: Reworked dictionary / bookshelf thread-safety model

### DIFF
--- a/components/masking_functions/include/masking_functions/bookshelf.hpp
+++ b/components/masking_functions/include/masking_functions/bookshelf.hpp
@@ -18,8 +18,8 @@
 
 #include "masking_functions/bookshelf_fwd.hpp"
 
-#include <shared_mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "masking_functions/dictionary_fwd.hpp"
@@ -28,16 +28,18 @@ namespace masking_functions {
 
 class bookshelf {
  public:
-  bookshelf() = default;
+  bookshelf();
   bookshelf(const dictionary &) = delete;
   bookshelf(bookshelf &&) = delete;
   bookshelf &operator=(const bookshelf &) = delete;
   bookshelf &operator=(bookshelf &&) = delete;
+  ~bookshelf();
 
   bool contains(const std::string &dictionary_name,
                 const std::string &term) const noexcept;
-  // returning a copy deliberately for thread safety
-  optional_string get_random(const std::string &dictionary_name) const noexcept;
+  // returns empty std::string_view if no such dictionary exist
+  std::string_view get_random(
+      const std::string &dictionary_name) const noexcept;
   bool remove(const std::string &dictionary_name) noexcept;
   bool remove(const std::string &dictionary_name,
               const std::string &term) noexcept;
@@ -49,10 +51,6 @@ class bookshelf {
   //       transparent_string_like_hash, std::equal_to<>>.
   using dictionary_container = std::unordered_map<std::string, dictionary_ptr>;
   dictionary_container dictionaries_;
-  mutable std::shared_mutex dictionaries_mutex_;
-
-  dictionary_ptr find_dictionary_internal(
-      const std::string &dictionary_name) const noexcept;
 };
 
 }  // namespace masking_functions

--- a/components/masking_functions/include/masking_functions/bookshelf_fwd.hpp
+++ b/components/masking_functions/include/masking_functions/bookshelf_fwd.hpp
@@ -22,7 +22,7 @@ namespace masking_functions {
 
 class bookshelf;
 
-using bookshelf_ptr = std::shared_ptr<bookshelf>;
+using bookshelf_ptr = std::unique_ptr<bookshelf>;
 
 }  // namespace masking_functions
 

--- a/components/masking_functions/include/masking_functions/dictionary.hpp
+++ b/components/masking_functions/include/masking_functions/dictionary.hpp
@@ -18,8 +18,8 @@
 
 #include "masking_functions/dictionary_fwd.hpp"
 
-#include <shared_mutex>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 namespace masking_functions {
@@ -34,9 +34,13 @@ class dictionary {
   dictionary &operator=(const dictionary &) = delete;
   dictionary &operator=(dictionary &&) = delete;
 
+  ~dictionary() = default;
+
+  bool is_empty() const noexcept { return terms_.empty(); }
+
   bool contains(const std::string &term) const noexcept;
-  // returning a copy deliberately for thread safety
-  optional_string get_random() const;
+  // returns empty std::string_view if the dictionary is empty
+  std::string_view get_random() const noexcept;
   bool insert(const std::string &term);
   bool remove(const std::string &term) noexcept;
 
@@ -46,7 +50,6 @@ class dictionary {
   //       transparent_string_like_hash, std::equal_to<>>.
   using term_container = std::unordered_set<std::string>;
   term_container terms_;
-  mutable std::shared_mutex terms_mutex_;
 };
 
 }  // namespace masking_functions

--- a/components/masking_functions/include/masking_functions/dictionary_fwd.hpp
+++ b/components/masking_functions/include/masking_functions/dictionary_fwd.hpp
@@ -17,16 +17,12 @@
 #define MASKING_FUNCTIONS_DICTIONARY_FWD_HPP
 
 #include <memory>
-#include <optional>
-#include <string>
 
 namespace masking_functions {
 
-using optional_string = std::optional<std::string>;
-
 class dictionary;
 
-using dictionary_ptr = std::shared_ptr<dictionary>;
+using dictionary_ptr = std::unique_ptr<dictionary>;
 
 }  // namespace masking_functions
 

--- a/components/masking_functions/src/masking_functions/registration_routines.cpp
+++ b/components/masking_functions/src/masking_functions/registration_routines.cpp
@@ -976,9 +976,9 @@ class gen_blocklist_impl {
     auto sresult =
         global_query_cache::instance()->get_random(cs_dict_b_escaped);
 
-    if (sresult && !sresult->empty()) {
+    if (!sresult.empty()) {
       masking_functions::charset_string utf8_result{
-          global_string_services::instance(), *sresult,
+          global_string_services::instance(), sresult,
           masking_functions::charset_string::utf8mb4_collation_name};
       masking_functions::charset_string conversion_buffer;
       const auto &cs_result = masking_functions::smart_convert_to_collation(
@@ -1022,8 +1022,8 @@ class gen_dictionary_impl {
     auto sresult =
         global_query_cache::instance()->get_random(cs_dictionary_escaped);
 
-    if (sresult && !sresult->empty()) {
-      return *sresult;
+    if (!sresult.empty()) {
+      return sresult;
     }
 
     return std::nullopt;

--- a/components/masking_functions/src/masking_functions/sql_context.cpp
+++ b/components/masking_functions/src/masking_functions/sql_context.cpp
@@ -15,7 +15,6 @@
 
 #include <cassert>
 #include <memory>
-#include <optional>
 #include <stdexcept>
 #include <type_traits>
 
@@ -84,12 +83,12 @@ sql_context::sql_context(const command_service_tuple &services)
 bool sql_context::execute_dml(std::string_view query) {
   if ((*get_services().query->query)(to_mysql_h(impl_.get()), query.data(),
                                      query.length()) != 0) {
-    return false;
+    throw std::runtime_error{"Error while executing SQL DML query"};
   }
   std::uint64_t row_count = 0;
   if ((*get_services().query->affected_rows)(to_mysql_h(impl_.get()),
                                              &row_count) != 0) {
-    return false;
+    throw std::runtime_error{"Couldn't get number of affected rows"};
   }
   return row_count > 0;
 }
@@ -99,7 +98,7 @@ void sql_context::execute_select_internal(
     const row_internal_callback &callback) {
   if ((*get_services().query->query)(to_mysql_h(impl_.get()), query.data(),
                                      query.length()) != 0) {
-    throw std::runtime_error{"Error while executing SQL query"};
+    throw std::runtime_error{"Error while executing SQL select query"};
   }
 
   unsigned int actual_number_of_fields;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9148

Both 'dictionary' and 'bookshelf' classes no longer include their own 'std::shared_mutex' to protect data. Instead, we now have a single 'std::shared_mutex' at the 'query_cache' level.

The return value of the 'get_random()' method in both 'dictionary' and 'bookshelf' classes changed from 'optional_string' to 'std::string_view'. Empty (default constructed) 'std::string_view' is used as an indicator of an unsuccessful operation.
'get_random()' method in the 'query_cache' class still returns a string by value to avoid race conditions.

Changed the behaviour of the 'sql_context::execute_dml()' method - it now throws when SQL errors (like "no table found", etc.) occur.